### PR TITLE
ci: Dependency Review Action で PR 時に脆弱性をブロック

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,27 @@
+name: dependency review
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    if: ${{ github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: dependency review
+        uses: actions/dependency-review-action@v5
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,6 +7,10 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/dependency-review.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## 概要

Closes #75

PR で追加・更新される依存パッケージに既知の脆弱性が含まれる場合、CI で検知してブロックするワークフローを追加しました。

## 変更内容

`.github/workflows/dependency-review.yml` を新規追加。

## 設計の意図

- **トリガー・draft 除外** — 既存の `build.yml` と同じ条件に揃え、下書き PR では走らせない
- **`fail-on-severity: high`** — high / critical でジョブを失敗させる。Dependabot PR が low / moderate で毎回赤くなるのを避ける狙い。より厳しくするなら `moderate` に変更可
- **`comment-summary-in-pr: on-failure`** — 失敗時のみ PR にサマリをコメント。そのため `pull-requests: write` 権限を付与
- **`@v5`** — 現時点の最新リリース

## 注意点

Dependency Review Action は **Dependency Graph** が有効なリポジトリでのみ動作します。パブリックリポジトリなら既定で有効ですが、無効の場合は Settings → Security → Dependency graph をオンにしてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)