### PR TITLE
ci: dependency review の paths フィルタを廃止し常に実行する

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,10 +7,6 @@ on:
       - synchronize
       - reopened
       - ready_for_review
-    paths:
-      - 'package.json'
-      - 'package-lock.json'
-      - '.github/workflows/dependency-review.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## 背景

`dependency-review` はブランチ保護の必須ステータスチェックに登録されているが、ワークフロー側に paths フィルタが設定されていた。

```yaml
paths:
  - 'package.json'
  - 'package-lock.json'
  - '.github/workflows/dependency-review.yml'
```

このため `package.json` 系を変更しない PR では**ワークフロー自体が起動しない**。必須チェックは「起動しなかった」と「まだ終わっていない」を区別できないため、`Expected — Waiting for status to be reported` のまま永久に pending になりマージできなくなる。

## 変更内容

`dependency-review-action` は依存に変更がなければ即座に success で完了する軽量な処理（実測十数秒）のため、paths フィルタを外して全 PR で常時実行する。

## 補足

- `build` 側は元々 paths フィルタがないため変更不要
- 同様の問題を KadoProG/vending-machine-app でも修正済み
- `todo-frontend-react-v2` と `laravel-todo-app-v2` は paths フィルタ付きのワークフローが必須チェックに登録されていないため影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)