### PR TITLE
chore: npm audit fix で brace-expansion / nanoid の脆弱性を解消

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1718,16 +1718,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
@@ -2097,9 +2097,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4404,9 +4404,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## 概要

`npm audit` で検出された high 2 件の脆弱性を `npm audit fix` で解消します。

いずれも推移的依存のため **package.json の変更は不要**で、`package-lock.json` のみの更新です。`npm audit fix`（`--force` なし）は semver 範囲を破る更新を行わないため、直接依存の指定バージョンは変わっていません。

## 変更内容

| パッケージ | 変更前 | 変更後 | 経路 |
|---|---|---|---|
| `brace-expansion` | 1.1.11 | 1.1.18 | `eslint-plugin-react` → `minimatch@3` |
| `brace-expansion` | 5.0.5 | 5.0.9 | `typescript-eslint` → `@typescript-eslint/typescript-estree` → `minimatch@10` |
| `nanoid` | 3.3.16 | 3.3.18 | `vite` → `postcss` |

対応した Advisory:

- `brace-expansion` — ReDoS およびメモリ枯渇系の複数 DoS（GHSA-v6h2-p8h4-qcjw, GHSA-f886-m6hf-6m8v, GHSA-jxxr-4gwj-5jf2, GHSA-3jxr-9vmj-r5cp, GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895）
- `nanoid` — size が 0 のときカスタムジェネレータが無限ループする（GHSA-2v37-7h3g-55p8）

いずれもパッチバージョンの更新で breaking change はありません。

## 留意点: Node の engines 要件

`brace-expansion@5.0.9` で `engines` が `"18 || 20 || >=22"` → `"20 || >=22"` に変わり、Node 18 のサポートが外れています。

本プロジェクトは volta で Node 24.15.0 を固定しており、CI も `node-version-file: 'package.json'` で volta の指定を参照しているため**影響はありません**。

## 検証

- `npm run check-types` — 通過
- `npm run lint` — エラー 0（既存の `react-refresh/only-export-components` warning 6 件のみ。本変更とは無関係）
- `npm run build` — 成功
- クリーンな作業ディレクトリで `npm ci` を実行し、その環境でも `npm audit` が **0 vulnerabilities** であることを確認（ロックファイル単体で再現可能）

## 対応範囲外

`npm audit` は既知の脆弱性 DB との照合であり、「audit が 0 = 安全」ではありません。ビルド時に `gapi-script` 内の直接 `eval` 使用が警告として出ていますが、これは audit に現れないリスク要因です。同パッケージはメンテナンスが停止しているため、Google 公式のスクリプト読み込みへの移行は別 PR で検討の余地があります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)